### PR TITLE
Removed die() and added redirect

### DIFF
--- a/libraries/quickauth.php
+++ b/libraries/quickauth.php
@@ -242,7 +242,7 @@ class Quickauth
 
 		if (!in_array($group, $user_groups)) {
 			ui_set_error($this->locale['failed_restrict']);
-			die();
+			redirect($This->login);
 		}
 
 		return;


### PR DESCRIPTION
Just a simple contribution here, but I think the use of a die(); was too brutal.
A redirect seems a better choice.
